### PR TITLE
[Analytics] Relocated tracker ID

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,15 +15,23 @@ android {
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
         debug {
+            minifyEnabled false
+            debuggable true
+
+            buildConfigField "String", "GOOGLE_ANALYTICS_TRACKER", '"UA-68882401-2"'
+
             applicationIdSuffix '.daily'
             versionNameSuffix '-DEVEL'
+        }
+        release {
+            minifyEnabled false
+            debuggable false
+
+            buildConfigField "String", "GOOGLE_ANALYTICS_TRACKER", '"UA-68882401-2"'
+
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {

--- a/app/src/main/java/org/glucosio/android/GlucosioApplication.java
+++ b/app/src/main/java/org/glucosio/android/GlucosioApplication.java
@@ -24,17 +24,17 @@ public class GlucosioApplication extends Application {
 
     /**
      * Gets the default {@link Tracker} for this {@link Application}.
+     *
      * @return tracker
      */
     synchronized public Tracker getDefaultTracker() {
         if (mTracker == null) {
-            String TRACKER_ID = "UA-68882401-2";
             GoogleAnalytics analytics = GoogleAnalytics.getInstance(this);
             // To enable debug logging use: adb shell setprop log.tag.GAv4 DEBUG
-            mTracker = analytics.newTracker(TRACKER_ID);
+            mTracker = analytics.newTracker(BuildConfig.GOOGLE_ANALYTICS_TRACKER);
             mTracker.enableAdvertisingIdCollection(true);
 
-            if(BuildConfig.DEBUG) {
+            if (BuildConfig.DEBUG) {
                 GoogleAnalytics.getInstance(this).setAppOptOut(true);
                 Log.i("Glucosio", "DEBUG BUILD: ANALYTICS IS DISABLED");
             }


### PR DESCRIPTION
## Changes

- Replace the Google Analytics Tracker ID from an String on the Application class to a BuildField placed on the Gradle configuration file. This allow us to have different tracker IDs for different types of builds. Right now apparently it's disabled for Debug mode, but we can use this technique for "release", "beta" or whatever flavor.
- Added some debug flags to Gradle file so it's easier to test from Studio.