### PR TITLE
Allow comma as decimal separator when adding Glucose reading

### DIFF
--- a/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
@@ -81,25 +81,7 @@ public class AddGlucosePresenter extends AddReadingPresenter {
             if (number == null) {
                 activity.showErrorMessage();
             } else {
-                boolean isReadingAdded;
-                if ("mg/dL".equals(getUnitMeasuerement())) {
-                    int finalReading = number.intValue();
-                    GlucoseReading gReading = new GlucoseReading(finalReading, type, finalDateTime, notes);
-                    if (oldId == UNKNOWN_ID) {
-                        isReadingAdded = dB.addGlucoseReading(gReading);
-                    } else {
-                        isReadingAdded = dB.editGlucoseReading(oldId, gReading);
-                    }
-                } else {
-                    converter = new GlucosioConverter();
-                    int convertedReading = converter.glucoseToMgDl(number.doubleValue());
-                    GlucoseReading gReading = new GlucoseReading(convertedReading, type, finalDateTime, notes);
-                    if (oldId == UNKNOWN_ID) {
-                        isReadingAdded = dB.addGlucoseReading(gReading);
-                    } else {
-                        isReadingAdded = dB.editGlucoseReading(oldId, gReading);
-                    }
-                }
+                boolean isReadingAdded = createReading(type, notes, oldId, finalDateTime, number);
                 if (!isReadingAdded) {
                     activity.showDuplicateErrorMessage();
                 } else {
@@ -109,6 +91,24 @@ public class AddGlucosePresenter extends AddReadingPresenter {
         } else {
             activity.showErrorMessage();
         }
+    }
+
+    private boolean createReading(String type, String notes, long oldId, Date finalDateTime, Number number) {
+        boolean isReadingAdded;
+        int readingValue;
+        if ("mg/dL".equals(getUnitMeasuerement())) {
+            readingValue = number.intValue();
+        } else {
+            converter = new GlucosioConverter();
+            readingValue = converter.glucoseToMgDl(number.doubleValue());
+        }
+        GlucoseReading gReading = new GlucoseReading(readingValue, type, finalDateTime, notes);
+        if (oldId == UNKNOWN_ID) {
+            isReadingAdded = dB.addGlucoseReading(gReading);
+        } else {
+            isReadingAdded = dB.editGlucoseReading(oldId, gReading);
+        }
+        return isReadingAdded;
     }
 
     public Integer retrieveSpinnerID(String measuredTypeText, List<String> measuredTypelist) {

--- a/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 
 public class AddGlucosePresenter extends AddReadingPresenter {
+    private static final int UNKNOWN_ID = -1;
     private DatabaseHandler dB;
     private AddGlucoseActivity activity;
     private ReadingTools rTools;
@@ -70,49 +71,40 @@ public class AddGlucosePresenter extends AddReadingPresenter {
     }
 
     public void dialogOnAddButtonPressed(String time, String date, String reading, String type, String notes) {
-        if (validateDate(date) && validateTime(time) && validateGlucose(reading) && validateType(type)) {
-            Date finalDateTime = getReadingTime();
-            boolean isReadingAdded;
-            if ("mg/dL".equals(getUnitMeasuerement())) {
-                int finalReading = Integer.parseInt(reading);
-                GlucoseReading gReading = new GlucoseReading(finalReading, type, finalDateTime, notes);
-                isReadingAdded = dB.addGlucoseReading(gReading);
-            } else {
-                converter = new GlucosioConverter();
-                int convertedReading = converter.glucoseToMgDl(Double.parseDouble(reading));
-                GlucoseReading gReading = new GlucoseReading(convertedReading, type, finalDateTime, notes);
-
-                isReadingAdded = dB.addGlucoseReading(gReading);
-            }
-            if (!isReadingAdded) {
-                activity.showDuplicateErrorMessage();
-            } else {
-                activity.finishActivity();
-            }
-        } else {
-            activity.showErrorMessage();
-        }
+        dialogOnAddButtonPressed(time, date, reading, type, notes, UNKNOWN_ID);
     }
 
     public void dialogOnAddButtonPressed(String time, String date, String reading, String type, String notes, long oldId) {
         if (validateDate(date) && validateTime(time) && validateGlucose(reading) && validateType(type)) {
             Date finalDateTime = getReadingTime();
-            boolean isReadingAdded;
-            if ("mg/dL".equals(getUnitMeasuerement())) {
-                int finalReading = Integer.parseInt(reading);
-                GlucoseReading gReading = new GlucoseReading(finalReading, type, finalDateTime, notes);
-                isReadingAdded = dB.editGlucoseReading(oldId, gReading);
+            Number number = ReadingTools.parseReading(reading);
+            if (number == null) {
+                activity.showErrorMessage();
             } else {
-                converter = new GlucosioConverter();
-                int convertedReading = converter.glucoseToMgDl(Double.parseDouble(reading));
-                GlucoseReading gReading = new GlucoseReading(convertedReading, type, finalDateTime, notes);
-
-                isReadingAdded = dB.editGlucoseReading(oldId, gReading);
-            }
-            if (!isReadingAdded) {
-                activity.showDuplicateErrorMessage();
-            } else {
-                activity.finishActivity();
+                boolean isReadingAdded;
+                if ("mg/dL".equals(getUnitMeasuerement())) {
+                    int finalReading = number.intValue();
+                    GlucoseReading gReading = new GlucoseReading(finalReading, type, finalDateTime, notes);
+                    if (oldId == UNKNOWN_ID) {
+                        isReadingAdded = dB.addGlucoseReading(gReading);
+                    } else {
+                        isReadingAdded = dB.editGlucoseReading(oldId, gReading);
+                    }
+                } else {
+                    converter = new GlucosioConverter();
+                    int convertedReading = converter.glucoseToMgDl(number.doubleValue());
+                    GlucoseReading gReading = new GlucoseReading(convertedReading, type, finalDateTime, notes);
+                    if (oldId == UNKNOWN_ID) {
+                        isReadingAdded = dB.addGlucoseReading(gReading);
+                    } else {
+                        isReadingAdded = dB.editGlucoseReading(oldId, gReading);
+                    }
+                }
+                if (!isReadingAdded) {
+                    activity.showDuplicateErrorMessage();
+                } else {
+                    activity.finishActivity();
+                }
             }
         } else {
             activity.showErrorMessage();

--- a/app/src/main/java/org/glucosio/android/tools/ReadingTools.java
+++ b/app/src/main/java/org/glucosio/android/tools/ReadingTools.java
@@ -20,6 +20,11 @@
 
 package org.glucosio.android.tools;
 
+import android.support.annotation.Nullable;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+
 public class ReadingTools {
 
     public ReadingTools() {
@@ -43,6 +48,24 @@ public class ReadingTools {
             return 0; // before breakfast
         } else {
             return 8; // night time
+        }
+    }
+
+    /**
+     * A convenient method for parsing reading value based on user's locale
+     *
+     * @param reading reading number String
+     * @return reading Number
+     */
+    @Nullable
+    public static Number parseReading(String reading) {
+        if (reading == null)
+            return null;
+        NumberFormat numberFormat = NumberFormat.getInstance();
+        try {
+            return numberFormat.parse(reading);
+        } catch (ParseException e) {
+            return null;
         }
     }
 }

--- a/app/src/main/res/layout/activity_add_glucose.xml
+++ b/app/src/main/res/layout/activity_add_glucose.xml
@@ -90,6 +90,7 @@
                             android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
                             android:hint="@string/dialog_add_concentration"
+                            android:digits="0123456789.,"
                             android:inputType="numberDecimal"
                             android:singleLine="true"
                             android:textColorHighlight="@color/glucosio_pink"

--- a/app/src/test/java/org/glucosio/android/tools/ReadingToolsTest.java
+++ b/app/src/test/java/org/glucosio/android/tools/ReadingToolsTest.java
@@ -1,0 +1,32 @@
+package org.glucosio.android.tools;
+
+import org.glucosio.android.RobolectricTest;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReadingToolsTest extends RobolectricTest {
+    @Test
+    public void shouldReturnNull_whenNullStringPassed() {
+        assertThat(ReadingTools.parseReading(null)).isNull();
+    }
+
+    @Test
+    public void shouldReturnNull_whenInvalidStringPassed() {
+        assertThat(ReadingTools.parseReading("abc")).isNull();
+    }
+
+    @Test
+    public void shouldReturnCorrectNumber_whenDotIsDecimalSeparator() {
+        Locale.setDefault(new Locale("en"));
+        assertThat(ReadingTools.parseReading("1.23").doubleValue()).isEqualTo(1.23);
+    }
+
+    @Test
+    public void shouldReturnCorrectNumber_whenCommaIsDecimalSeparator() {
+        Locale.setDefault(new Locale("fr"));
+        assertThat(ReadingTools.parseReading("1,23").doubleValue()).isEqualTo(1.23);
+    }
+}

--- a/app/src/test/java/org/glucosio/android/tools/ReadingToolsTest.java
+++ b/app/src/test/java/org/glucosio/android/tools/ReadingToolsTest.java
@@ -1,13 +1,27 @@
 package org.glucosio.android.tools;
 
-import org.glucosio.android.RobolectricTest;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ReadingToolsTest extends RobolectricTest {
+public class ReadingToolsTest {
+
+    private Locale defaultLocale;
+
+    @Before
+    public void setUp() {
+        defaultLocale = Locale.getDefault();
+    }
+
+    @After
+    public void after() {
+        Locale.setDefault(defaultLocale);
+    }
+
     @Test
     public void shouldReturnNull_whenNullStringPassed() {
         assertThat(ReadingTools.parseReading(null)).isNull();


### PR DESCRIPTION
addresses https://github.com/Glucosio/glucosio-android/issues/187 (hacktoberfest)

note:
I use `NumberFormat#parse` to parse the reading value. 

if you prefer
> "Assuming the right-most comma or period as the decimal separator and stripping any other periods and commas should also work."

I will update my PR

thanks!