### PR TITLE
Remove hardcoded strings for concentrations like mg/dL

### DIFF
--- a/app/src/main/java/org/glucosio/android/activity/AddA1CActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddA1CActivity.java
@@ -62,7 +62,7 @@ public class AddA1CActivity extends AddReadingActivity {
         this.createFANViewAndListener();
 
         if (!"percentage".equals(presenter.getA1CUnitMeasuerement())) {
-            unitTextView.setText("mmol/mol");
+            unitTextView.setText(getString(R.string.mmol_mol));
         }
 
         // If an id is passed, open the activity in edit mode

--- a/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
@@ -108,9 +108,9 @@ public class AddGlucoseActivity extends AddReadingActivity {
         TextView unitM = (TextView) findViewById(R.id.glucose_add_unit_measurement);
 
         if (presenter.getUnitMeasuerement().equals("mg/dL")) {
-            unitM.setText("mg/dL");
+            unitM.setText(getString(R.string.mg_dL));
         } else {
-            unitM.setText("mmol/L");
+            unitM.setText(getString(R.string.mmol_L));
         }
 
         // If an id is passed, open the activity in edit mode

--- a/app/src/main/java/org/glucosio/android/adapter/A1cEstimateAdapter.java
+++ b/app/src/main/java/org/glucosio/android/adapter/A1cEstimateAdapter.java
@@ -13,6 +13,7 @@ import org.glucosio.android.db.DatabaseHandler;
 import org.glucosio.android.object.A1cEstimate;
 import org.glucosio.android.tools.GlucosioConverter;
 
+import java.text.NumberFormat;
 import java.util.List;
 
 public class A1cEstimateAdapter extends ArrayAdapter<A1cEstimate> {
@@ -66,8 +67,9 @@ public class A1cEstimateAdapter extends ArrayAdapter<A1cEstimate> {
                     glucoseAverage.setText(getContext().getString(R.string.mg_dL_value, p.getGlucoseAverage()));
                 } else {
                     GlucosioConverter converter = new GlucosioConverter();
-                    String mmol = String.valueOf(converter.glucoseToMgDl(Double.parseDouble(p.getGlucoseAverage())));
-                    glucoseAverage.setText(getContext().getString(R.string.mmol_L_value, mmol));
+                    int mmol = converter.glucoseToMgDl(Double.parseDouble(p.getGlucoseAverage()));
+                    String reading = NumberFormat.getInstance().format(mmol);
+                    glucoseAverage.setText(getContext().getString(R.string.mmol_L_value, reading));
                 }
             }
         }

--- a/app/src/main/java/org/glucosio/android/adapter/A1cEstimateAdapter.java
+++ b/app/src/main/java/org/glucosio/android/adapter/A1cEstimateAdapter.java
@@ -63,10 +63,11 @@ public class A1cEstimateAdapter extends ArrayAdapter<A1cEstimate> {
 
             if (glucoseAverage != null) {
                 if ("mg/dL".equals(db.getUser(1).getPreferred_unit())) {
-                    glucoseAverage.setText(p.getGlucoseAverage() + " mg/dL");
+                    glucoseAverage.setText(getContext().getString(R.string.mg_dL_value, p.getGlucoseAverage()));
                 } else {
                     GlucosioConverter converter = new GlucosioConverter();
-                    glucoseAverage.setText(converter.glucoseToMgDl(Double.parseDouble(p.getGlucoseAverage())) + " mmol/L");
+                    String mmol = String.valueOf(converter.glucoseToMgDl(Double.parseDouble(p.getGlucoseAverage())));
+                    glucoseAverage.setText(getContext().getString(R.string.mmol_L_value, mmol));
                 }
             }
         }

--- a/app/src/main/java/org/glucosio/android/adapter/HistoryAdapter.java
+++ b/app/src/main/java/org/glucosio/android/adapter/HistoryAdapter.java
@@ -153,9 +153,12 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHold
                 String color = ranges.colorFromReading(glucoseReadingArray.get(position));
 
                 if (presenter.getUnitMeasuerement().equals("mg/dL")) {
-                    readingTextView.setText(glucoseReadingArray.get(position).toString() + " mg/dL");
+                    String reading = glucoseReadingArray.get(position).toString();
+                    readingTextView.setText(mContext.getString(R.string.mg_dL_value, reading));
                 } else {
-                    readingTextView.setText(converter.glucoseToMmolL(Double.parseDouble(glucoseReadingArray.get(position).toString())) + " mmol/L");
+                    String mgdlReading = glucoseReadingArray.get(position).toString();
+                    String reading = String.valueOf(converter.glucoseToMmolL(Double.parseDouble(mgdlReading)));
+                    readingTextView.setText(mContext.getString(R.string.mmol_L_value, reading));
                 }
 
                 readingTextView.setTextColor(ranges.stringToColor(color));
@@ -174,7 +177,8 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHold
                     readingTextView.setText(hb1acReadingArray.get(position).toString() + " %");
                 } else {
                     GlucosioConverter converter = new GlucosioConverter();
-                    readingTextView.setText(converter.a1cNgspToIfcc(hb1acReadingArray.get(position)) + " mmol/mol");
+                    String reading = String.valueOf(converter.a1cNgspToIfcc(hb1acReadingArray.get(position)));
+                    readingTextView.setText(mContext.getString(R.string.mmol_mol_value, reading));
                 }
                 datetimeTextView.setText(presenter.convertDate(hb1acDateTimeArray.get(position)));
                 typeTextView.setText("");
@@ -184,7 +188,8 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHold
             // Cholesterol
             case 2:
                 idTextView.setText(cholesterolIdArray.get(position).toString());
-                readingTextView.setText(cholesterolTotalArray.get(position).toString() + " mg/dL");
+                String reading = cholesterolTotalArray.get(position).toString();
+                readingTextView.setText(mContext.getString(R.string.mg_dL_value, reading));
                 datetimeTextView.setText(presenter.convertDate(cholesterolDateTimeArray.get(position)));
                 typeTextView.setText("LDL: " + cholesterolLDLArray.get(position) + " - " + "HDL: " + cholesterolHDLArray.get(position));
                 readingTextView.setTextColor(mContext.getResources().getColor(R.color.glucosio_text_dark));

--- a/app/src/main/java/org/glucosio/android/adapter/HistoryAdapter.java
+++ b/app/src/main/java/org/glucosio/android/adapter/HistoryAdapter.java
@@ -32,6 +32,7 @@ import org.glucosio.android.presenter.HistoryPresenter;
 import org.glucosio.android.tools.GlucoseRanges;
 import org.glucosio.android.tools.GlucosioConverter;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -153,11 +154,12 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHold
                 String color = ranges.colorFromReading(glucoseReadingArray.get(position));
 
                 if (presenter.getUnitMeasuerement().equals("mg/dL")) {
-                    String reading = glucoseReadingArray.get(position).toString();
+                    int glucoseReading = glucoseReadingArray.get(position);
+                    String reading = NumberFormat.getInstance().format(glucoseReading);
                     readingTextView.setText(mContext.getString(R.string.mg_dL_value, reading));
                 } else {
-                    String mgdlReading = glucoseReadingArray.get(position).toString();
-                    String reading = String.valueOf(converter.glucoseToMmolL(Double.parseDouble(mgdlReading)));
+                    double mmol = converter.glucoseToMmolL(glucoseReadingArray.get(position));
+                    String reading = NumberFormat.getInstance().format(mmol);
                     readingTextView.setText(mContext.getString(R.string.mmol_L_value, reading));
                 }
 
@@ -177,7 +179,8 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHold
                     readingTextView.setText(hb1acReadingArray.get(position).toString() + " %");
                 } else {
                     GlucosioConverter converter = new GlucosioConverter();
-                    String reading = String.valueOf(converter.a1cNgspToIfcc(hb1acReadingArray.get(position)));
+                    double ifcc = converter.a1cNgspToIfcc(hb1acReadingArray.get(position));
+                    String reading = NumberFormat.getInstance().format(ifcc);
                     readingTextView.setText(mContext.getString(R.string.mmol_mol_value, reading));
                 }
                 datetimeTextView.setText(presenter.convertDate(hb1acDateTimeArray.get(position)));

--- a/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
+++ b/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
@@ -68,6 +68,7 @@ import org.glucosio.android.tools.GlucosioConverter;
 import org.glucosio.android.tools.TipsManager;
 import org.glucosio.android.view.OverviewView;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -663,7 +664,8 @@ public class OverviewFragment extends Fragment implements OverviewView {
             } else {
                 GlucosioConverter converter = new GlucosioConverter();
                 String mgdl = presenter.getLastReading();
-                String reading = String.valueOf(converter.glucoseToMmolL(Double.parseDouble(mgdl)));
+                double mmol = converter.glucoseToMmolL(Double.parseDouble(mgdl));
+                String reading = NumberFormat.getInstance().format(mmol);
                 lastReadingTextView.setText(getString(R.string.mmol_L_value, reading));
             }
 

--- a/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
+++ b/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
@@ -658,10 +658,13 @@ public class OverviewFragment extends Fragment implements OverviewView {
     private void loadLastReading() {
         if (!presenter.isdbEmpty()) {
             if (presenter.getUnitMeasuerement().equals("mg/dL")) {
-                lastReadingTextView.setText(presenter.getLastReading() + " mg/dL");
+                String reading = presenter.getLastReading();
+                lastReadingTextView.setText(getString(R.string.mg_dL_value, reading));
             } else {
                 GlucosioConverter converter = new GlucosioConverter();
-                lastReadingTextView.setText(converter.glucoseToMmolL(Double.parseDouble(presenter.getLastReading())) + " mmol/L");
+                String mgdl = presenter.getLastReading();
+                String reading = String.valueOf(converter.glucoseToMmolL(Double.parseDouble(mgdl)));
+                lastReadingTextView.setText(getString(R.string.mmol_L_value, reading));
             }
 
             FormatDateTime dateTime = new FormatDateTime(getActivity().getApplicationContext());

--- a/app/src/main/java/org/glucosio/android/object/A1cEstimate.java
+++ b/app/src/main/java/org/glucosio/android/object/A1cEstimate.java
@@ -2,6 +2,8 @@ package org.glucosio.android.object;
 
 import org.glucosio.android.tools.GlucosioConverter;
 
+import java.text.NumberFormat;
+
 public class A1cEstimate {
     private double value;
     private String month;
@@ -29,6 +31,6 @@ public class A1cEstimate {
 
     public String getGlucoseAverage() {
         GlucosioConverter conveter = new GlucosioConverter();
-        return conveter.a1cToGlucose(value) + "";
+        return NumberFormat.getInstance().format(conveter.a1cToGlucose(value));
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,6 +443,10 @@
     <string name="activity_backup_drive_button_open_drive">Manage on Drive</string>
     <string name="mmol_mol">mmol/mol</string>
     <string name="mmol_L">mmol/L</string>
+    <string name="mmol_mol_value">%1$s mmol/mol</string>
+    <string name="mmol_L_value">%1$s mmol/L</string>
+    <string name="mg_dL">mg/dL</string>
+    <string name="mg_dL_value">%1$s mg/dL</string>
     <string name="preferences_graph_old">Revert to old graph</string>
     <string name="history">history</string>
     <string name="save">save</string>


### PR DESCRIPTION
This addresses the issue of hardcoded strings mentioned in issue #303 