### PR TITLE
Fix mmol and a1c bugs

### DIFF
--- a/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
@@ -119,7 +119,11 @@ public class AddGlucoseActivity extends AddReadingActivity {
         if (this.isEditing()) {
             setTitle(R.string.title_activity_add_glucose_edit);
             GlucoseReading readingToEdit = presenter.getGlucoseReadingById(this.getEditId());
-            readingTextView.setText(readingToEdit.getReading() + "");
+            if (presenter.getUnitMeasuerement().equals("mg/dL")) {
+                readingTextView.setText(String.valueOf(readingToEdit.getReading()));
+            } else {
+                readingTextView.setText(String.valueOf(presenter.convertToMmol(readingToEdit.getReading())));
+            }
             notesEditText.setText(readingToEdit.getNotes());
             cal.setTime(readingToEdit.getCreated());
             this.getAddDateTextView().setText(dateTime.getDate(cal));

--- a/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
@@ -119,11 +119,15 @@ public class AddGlucoseActivity extends AddReadingActivity {
         if (this.isEditing()) {
             setTitle(R.string.title_activity_add_glucose_edit);
             GlucoseReading readingToEdit = presenter.getGlucoseReadingById(this.getEditId());
+
+            String readingString;
             if (presenter.getUnitMeasuerement().equals("mg/dL")) {
-                readingTextView.setText(String.valueOf(readingToEdit.getReading()));
+                readingString = String.valueOf(readingToEdit.getReading());
             } else {
-                readingTextView.setText(String.valueOf(presenter.convertToMmol(readingToEdit.getReading())));
+                readingString = String.valueOf(presenter.convertToMmol(readingToEdit.getReading()));
             }
+
+            readingTextView.setText(readingString);
             notesEditText.setText(readingToEdit.getNotes());
             cal.setTime(readingToEdit.getCreated());
             this.getAddDateTextView().setText(dateTime.getDate(cal));

--- a/app/src/main/java/org/glucosio/android/presenter/A1CCalculatorPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/A1CCalculatorPresenter.java
@@ -72,7 +72,14 @@ public class A1CCalculatorPresenter {
     }
 
     public void saveA1C(double a1c) {
-        HB1ACReading a1cReading = new HB1ACReading(a1c, new Date());
+        User user = dbHandler.getUser(1);
+        double finalA1c = a1c;
+        if (!"percentage".equals(user.getPreferred_unit_a1c())) {
+            GlucosioConverter converter = new GlucosioConverter();
+            finalA1c = converter.a1cIfccToNgsp(a1c);
+        }
+
+        HB1ACReading a1cReading = new HB1ACReading(finalA1c, new Date());
         dbHandler.addHB1ACReading(a1cReading);
         activity.finish();
     }

--- a/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/AddGlucosePresenter.java
@@ -49,6 +49,7 @@ public class AddGlucosePresenter extends AddReadingPresenter {
         this.activity = addGlucoseActivity;
         dB = new DatabaseHandler(addGlucoseActivity.getApplicationContext());
         rTools = new ReadingTools();
+        converter = new GlucosioConverter();
     }
 
     public void updateSpinnerTypeTime() {
@@ -99,7 +100,6 @@ public class AddGlucosePresenter extends AddReadingPresenter {
         if ("mg/dL".equals(getUnitMeasuerement())) {
             readingValue = number.intValue();
         } else {
-            converter = new GlucosioConverter();
             readingValue = converter.glucoseToMgDl(number.doubleValue());
         }
         GlucoseReading gReading = new GlucoseReading(readingValue, type, finalDateTime, notes);
@@ -109,6 +109,10 @@ public class AddGlucosePresenter extends AddReadingPresenter {
             isReadingAdded = dB.editGlucoseReading(oldId, gReading);
         }
         return isReadingAdded;
+    }
+
+    public double convertToMmol(int mgDl) {
+        return converter.glucoseToMmolL(mgDl);
     }
 
     public Integer retrieveSpinnerID(String measuredTypeText, List<String> measuredTypelist) {


### PR DESCRIPTION
A1C:
"Not sure but there might be a bug in Android HbA1c calculator - if set glucose units to mmol/L and HbA1c units to mmol/mol, save button saves as if units for HbA1c is percentage"

MMOL:
"When using mmol/L and edit a glucose value, the value is presented with the mg/DL, when saved without changing the value (you only change the time), then you have the mg/DL value as if it was mmol/L. 
Need to convert the stored value back to mmol/L before displaying it on the edit page."