### PR TITLE
[RFC] Support 'Almost' translated languages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ def getAllLocales() {
 
     fileTree("src/main/res").visit { FileVisitDetails details ->
         if (details.file.path.endsWith("strings.xml")) {
-            def languageCode = details.file.parent.tokenize('/').last().replaceAll('values-', '').replaceAll('-r', '-')
+            def languageCode = details.file.parent.tokenize('/\\').last().replaceAll('values-', '').replaceAll('-r', '-')
             languageCode = (languageCode == "values") ? "en" : languageCode;
             foundLocales.append("\"").append(languageCode).append("\"").append(",")
         }

--- a/app/src/main/java/org/glucosio/android/activity/MainActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/MainActivity.java
@@ -69,6 +69,7 @@ import org.glucosio.android.analytics.Analytics;
 import org.glucosio.android.db.DatabaseHandler;
 import org.glucosio.android.presenter.ExportPresenter;
 import org.glucosio.android.presenter.MainPresenter;
+import org.glucosio.android.tools.LocaleHelper;
 import org.glucosio.android.view.ExportView;
 
 import java.util.Calendar;
@@ -93,6 +94,7 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
     private TextView exportDialogDateTo;
     private View bottomSheetAddDialogView;
     private TabLayout tabLayout;
+    private LocaleHelper localeHelper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -100,8 +102,8 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
 
         GlucosioApplication application = (GlucosioApplication) getApplication();
 
-        setContentView(R.layout.activity_main);
         initPresenters(application);
+        setContentView(R.layout.activity_main);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.activity_main_toolbar);
         tabLayout = (TabLayout) findViewById(R.id.activity_main_tab_layout);
@@ -265,6 +267,7 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
 
     private void initPresenters(GlucosioApplication application) {
         final DatabaseHandler dbHandler = application.getDBHandler();
+        localeHelper = new LocaleHelper();
         presenter = new MainPresenter(this, dbHandler);
         exportPresenter = new ExportPresenter(this, dbHandler);
     }
@@ -570,6 +573,8 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
     public Toolbar getToolbar() {
         return (Toolbar) findViewById(R.id.activity_main_toolbar);
     }
+
+    public LocaleHelper getLocaleHelper() { return localeHelper; }
 
     private void hideFabAnimation() {
         final View fab = findViewById(R.id.activity_main_fab_add_reading);

--- a/app/src/main/java/org/glucosio/android/presenter/MainPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/MainPresenter.java
@@ -31,10 +31,14 @@ public class MainPresenter {
 
     public MainPresenter(MainActivity mainActivity, DatabaseHandler databaseHandler) {
         dB = databaseHandler;
-        Log.i("msg::", "initiated db object");
+        Log.i("msg::", "initiated dB object");
         if (dB.getUser(1) == null) {
             // if user doesn't exists start hello activity
             mainActivity.startHelloActivity();
+        } else {
+            // If user already exists, update user's preferred language and recreate MainActivity
+            mainActivity.getLocaleHelper().updateLanguage(mainActivity,
+                                                          dB.getUser(1).getPreferred_language());
         }
     }
 

--- a/app/src/main/java/org/glucosio/android/tools/LocaleHelper.java
+++ b/app/src/main/java/org/glucosio/android/tools/LocaleHelper.java
@@ -8,7 +8,6 @@ import android.util.DisplayMetrics;
 
 import org.glucosio.android.BuildConfig;
 import org.glucosio.android.R;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -46,6 +45,7 @@ public class LocaleHelper {
         // Change locale settings in the app.
         DisplayMetrics dm = res.getDisplayMetrics();
         Configuration conf = res.getConfiguration();
+        // TODO(raacker): deprecated. change to setLocale(). It needs to be set minSdk to 17. Configure project's minSdk first
         conf.locale = locale;
         res.updateConfiguration(conf, dm);
 
@@ -54,35 +54,20 @@ public class LocaleHelper {
 
     @NonNull
     public List<String> getLocalesWithTranslation(final Resources resources) {
-        String[] languages = BuildConfig.TRANSLATION_ARRAY;
+        String[] languageList = BuildConfig.TRANSLATION_ARRAY;
         Set<String> availableLanguagesSet = new HashSet<>();
-        // We always support english
+
+        // Glucosio support English as default
         availableLanguagesSet.add("en");
 
-        // Get english string to confront
-        // I know, it's a weird workaround
-        // Sorry :/
-        String englishString = "Automatic backup";
+        String[] translatedLanguages = resources.getStringArray(R.array.available_languages);
+        Set<String> translatedLanguageSet = new HashSet<>();
 
-        for (String localString : languages) {
-            // For each locale, check if we have translations
-            Configuration conf = resources.getConfiguration();
-            Locale savedLocale = conf.locale;
-            conf.locale = getLocale(localString);
-            resources.updateConfiguration(conf, null);
+        Collections.addAll(translatedLanguageSet, translatedLanguages);
 
-            // Retrieve an example string from this locale
-            String localizedString = resources.getString(R.string.activity_backup_drive_automatic);
-
-            if (!englishString.equals(localizedString)) {
-                // if english string is not the same of localized one
-                // a translation is available
-                availableLanguagesSet.add(localString);
-            }
-
-            // restore original locale
-            conf.locale = savedLocale;
-            resources.updateConfiguration(conf, null);
+        for (String language : languageList) {
+            if (translatedLanguageSet.contains(language.substring(0, 5)))
+                availableLanguagesSet.add(language);
         }
 
         List<String> availableLanguagesList = new ArrayList<>(availableLanguagesSet);
@@ -91,6 +76,7 @@ public class LocaleHelper {
     }
 
     public Locale getDeviceLocale() {
+        // TODO(raacker): deprecated. change to getLocale(). It needs to be set minSdk to 17. Configure project's minSdk first
         return Resources.getSystem().getConfiguration().locale;
     }
 }

--- a/app/src/main/res/values/available_languages.xml
+++ b/app/src/main/res/values/available_languages.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="available_languages">
+        <item>en-US</item>
+        <item>en</item>
+        <item>ko-KR</item>
+        <item>ca-ES</item>
+        <item>nl-NL</item>
+        <item>gl-ES</item>
+        <item>it-IT</item>
+        <item>lo-LA</item>
+        <item>ru-RU</item>
+        <item>sl-Sl</item>
+        <item>fr-FR</item>
+        <item>de-DE</item>
+        <item>pt-BR</item>
+        <item>es-ES</item>
+        <item>es-CL</item>
+        <item>es-MX</item>
+        <item>es-VE</item>
+        <item>ga-IE</item>
+        <item>en-GB</item>
+        <item>hr-HR</item>
+        <item>zh-TW</item>
+        <item>zh-CN</item>
+        <item>ar-SA</item>
+        <item>sq-AL</item>
+        <item>ja-JP</item>
+    </string-array>
+    <!-- Supported Languages : 24
+        English : en-US, en
+        Korean : ko-KR
+        Catalan : ca-ES
+        Dutch : nl-NL
+        Galician : gl-ES
+        Italian : it-IT
+        Lao : lo-LA
+        Russian : ru-RU
+        Slovenian : sl-Sl
+        French : fr-FR
+        German : de-DE
+        Portuguese, Brazilian : pt-BR
+        Spanish : es-ES
+        Spanish, Chile : es-CL
+        Spanish, Mexico : es-MX
+        Spanish, Venezuela : es-VE
+        Irish : ga-IE
+        English : en-GB
+        Croatian : hr-HR
+        Chinese Traditional : zh-TW
+        Chinese Simplified : zh-CN
+        Arabic : ar-SA
+        Albanian : sq-AL
+        Japanese : ja-JP
+    -->
+</resources>

--- a/app/src/test/java/org/glucosio/android/tools/LocaleHelperTest.java
+++ b/app/src/test/java/org/glucosio/android/tools/LocaleHelperTest.java
@@ -14,7 +14,7 @@ public class LocaleHelperTest extends RobolectricTest {
     private LocaleHelper helper = new LocaleHelper();
 
     @Test
-    public void ShouldReturnAtLEastEnglish_WhenAsked() throws Exception {
+    public void ShouldReturnAtLeastEnglish_WhenAsked() throws Exception {
         final Resources resources = RuntimeEnvironment.application.getResources();
 
         final List<String> localesWithTranslation = helper.getLocalesWithTranslation(resources);

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         // TODO: Please revert to a stable gradle version before releasing on prod
         // Alpha is required in devel to use Instant Run and speed up development process
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'io.realm:realm-gradle-plugin:1.1.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'


### PR DESCRIPTION
This PR support more languages. So it fixes #297 

This application is used in various countries. And in Crowdin, some languages are already 100% translated or almost translated. But Glucosio is still support only English. These features are enhancement of it. And also, you can find Crowdin's API for translation status. But there are too many non-translated languages and it was useless to get it's all data. The API needs Auth key so until it is cleared, just maintaining available strings manually would be better. I already made code, but I will just keep it.

- Add available_languages.xml of 'almost' translated languages
- Add updateLocale code on MainPresenter when there is already user profile in DB
- Swap two codes order of calling MainPresenter for update MainActivities in start
- Add localeHelper variable for MainActivity
- Changed getLocalesWithTranslation to available languages
- Fixed bug in build.gradle. It should contain one more backslash