### PR TITLE
Modified error code of a1c converting

### DIFF
--- a/app/src/main/java/org/glucosio/android/presenter/A1CCalculatorPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/A1CCalculatorPresenter.java
@@ -54,7 +54,7 @@ public class A1CCalculatorPresenter {
         } else {
             convertedA1C = converter.glucoseToA1C(converter.glucoseToMgDl(Double.parseDouble(glucose)));
         }
-        if (!"percentage".equals(user.getPreferred_unit_a1c())) {
+        if ("percentage".equals(user.getPreferred_unit_a1c())) {
             return converter.a1cNgspToIfcc(convertedA1C);
         } else {
             return convertedA1C;


### PR DESCRIPTION
I was writing test code of A1CCalculaterPresenter and there was a logical error.

if user prefers percentage, it should be convertedto mmol/mol.

but it is calling NgspToIfcc when it is not percentage. 