### PR TITLE
Remove duplicated method and change name of original one

### DIFF
--- a/app/src/main/java/org/glucosio/android/db/DatabaseHandler.java
+++ b/app/src/main/java/org/glucosio/android/db/DatabaseHandler.java
@@ -289,7 +289,7 @@ public class DatabaseHandler {
         return readingList;
     }
 
-    public GlucoseReading getGlucoseReading(long id) {
+    public GlucoseReading getGlucoseReadingById(long id) {
         return realm.where(GlucoseReading.class)
                 .equalTo("id", id)
                 .findFirst();
@@ -378,11 +378,6 @@ public class DatabaseHandler {
     public Date getLastGlucoseDateTime() {
         return realm.where(GlucoseReading.class).maximumDate("created");
     }
-
-    public GlucoseReading getGlucoseReadingById(long id) {
-        return getGlucoseReading(id);
-    }
-
 
 /*    private ArrayList<Integer> getGlucoseReadingsForLastMonthAsArray(){
         Calendar calendar = Calendar.getInstance();

--- a/app/src/main/java/org/glucosio/android/presenter/HistoryPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/HistoryPresenter.java
@@ -48,7 +48,7 @@ public class HistoryPresenter {
         switch (metricID) {
             // Glucose
             case 0:
-                dB.deleteGlucoseReading(dB.getGlucoseReading(idToDelete));
+                dB.deleteGlucoseReading(dB.getGlucoseReadingById(idToDelete));
                 fragment.reloadFragmentAdapter();
                 break;
             // HB1AC

--- a/app/src/test/java/org/glucosio/android/presenter/ExportPresenterTest.java
+++ b/app/src/test/java/org/glucosio/android/presenter/ExportPresenterTest.java
@@ -31,7 +31,7 @@ public class ExportPresenterTest extends RobolectricTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        when(dbHandlerMock.getGlucoseReading(anyLong())).thenReturn(glucoseReadingMock);
+        when(dbHandlerMock.getGlucoseReadingById(anyLong())).thenReturn(glucoseReadingMock);
         when(glucoseReadingMock.getNotes()).thenReturn(MOCK_NOTE_FOR_TEST);
         when(glucoseReadingMock.getCreated()).thenReturn(new Date());
         when(glucoseReadingMock.getReading()).thenReturn(TEST_READING_VALUE);


### PR DESCRIPTION
getGlucoseReadingById is calling getGlucoseReading. And getGlucoseReading is
just using id for its search! 

They are duplicated and just getGlucoseReadingById needed.