### PR TITLE
Remove duplicated method

### DIFF
--- a/app/src/main/java/org/glucosio/android/db/DatabaseHandler.java
+++ b/app/src/main/java/org/glucosio/android/db/DatabaseHandler.java
@@ -540,14 +540,10 @@ public class DatabaseHandler {
         realm.commitTransaction();
     }
 
-    public HB1ACReading getHB1ACReading(long id) {
+    public HB1ACReading getHB1ACReadingById(long id) {
         return realm.where(HB1ACReading.class)
                 .equalTo("id", id)
                 .findFirst();
-    }
-
-    public HB1ACReading getHB1ACReadingById(long id) {
-        return getHB1ACReading(id);
     }
 
     public void editHB1ACReading(long oldId, HB1ACReading reading) {
@@ -819,7 +815,7 @@ public class DatabaseHandler {
         addWeightReading(reading);
     }
 
-    public WeightReading getWeightReading(long id) {
+    public WeightReading getWeightReadingById(long id) {
         return realm.where(WeightReading.class)
                 .equalTo("id", id)
                 .findFirst();
@@ -886,10 +882,6 @@ public class DatabaseHandler {
         }
 
         return datetimeArray;
-    }
-
-    public WeightReading getWeightReadingById(long id) {
-        return getWeightReading(id);
     }
 
     public void addCholesterolReading(CholesterolReading reading) {

--- a/app/src/main/java/org/glucosio/android/presenter/HistoryPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/HistoryPresenter.java
@@ -53,7 +53,7 @@ public class HistoryPresenter {
                 break;
             // HB1AC
             case 1:
-                dB.deleteHB1ACReading(dB.getHB1ACReading(idToDelete));
+                dB.deleteHB1ACReading(dB.getHB1ACReadingById(idToDelete));
                 fragment.reloadFragmentAdapter();
                 break;
             // Cholesterol
@@ -73,7 +73,7 @@ public class HistoryPresenter {
                 break;
             // Weight
             case 5:
-                dB.deleteWeightReading(dB.getWeightReading(idToDelete));
+                dB.deleteWeightReading(dB.getWeightReadingById(idToDelete));
                 fragment.reloadFragmentAdapter();
                 break;
             default:


### PR DESCRIPTION
I think that getHB1ACReadingById method call getHB1ACReading and getWeightReadingById method call getWeightReading.
They are duplicated. So I rename them.