### PR TITLE
Glucose range display fixes

### DIFF
--- a/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
@@ -190,7 +190,6 @@ public class PreferencesActivity extends AppCompatActivity {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     updatedUser.setCountry(newValue.toString());
-
                     updateDB();
                     return false;
                 }
@@ -448,14 +447,15 @@ public class PreferencesActivity extends AppCompatActivity {
 
         private void updateDB() {
             dB.updateUser(updatedUser);
+
+            countryPref.setSummary(user.getCountry());
             agePref.setSummary(String.valueOf(user.getAge()));
             genderPref.setSummary(String.valueOf(user.getGender()));
-
             diabetesTypePref.setSummary(getResources().getStringArray(R.array.helloactivity_diabetes_type)[user.getD_type() - 1]);
             unitPrefGlucose.setSummary(getGlucoseUnitValue(user.getPreferred_unit()));
             unitPrefA1c.setSummary(getA1CUnitValue(user.getPreferred_unit_a1c()));
             unitPrefWeight.setSummary(getUnitWeight(user.getPreferred_unit_weight()));
-            countryPref.setSummary(user.getCountry());
+            rangePref.setSummary(user.getPreferred_range());
 
             if (user.getPreferred_unit().equals("mg/dL")) {
                 minRangePref.setSummary(String.valueOf(user.getCustom_range_min()));
@@ -464,14 +464,6 @@ public class PreferencesActivity extends AppCompatActivity {
                 minRangePref.setSummary(String.valueOf(GlucosioConverter.glucoseToMmolL(user.getCustom_range_min())));
                 maxRangePref.setSummary(String.valueOf(GlucosioConverter.glucoseToMmolL(user.getCustom_range_max())));
             }
-
-            countryPref.setValue(user.getCountry());
-            genderPref.setValue(user.getGender());
-            diabetesTypePref.setValue(String.valueOf(user.getD_type()));
-            unitPrefGlucose.setValue(user.getPreferred_unit());
-            genderPref.setValue(user.getGender());
-            unitPrefGlucose.setValue(user.getPreferred_unit());
-            rangePref.setValue(user.getPreferred_range());
 
             if (!user.getPreferred_range().equals("Custom range")) {
                 minRangePref.setEnabled(false);

--- a/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
@@ -276,12 +276,13 @@ public class PreferencesActivity extends AppCompatActivity {
             rangePref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    updatedUser.setPreferred_range(newValue.toString());
+                    String selectedPreset = newValue.toString();
+                    updatedUser.setPreferred_range(selectedPreset);
 
                     // look up the min/max values of the selected preset
-                    if (!newValue.toString().equals("Custom range")) {
-                        int rangeMin = GlucoseRanges.rangePresetToMin(newValue.toString());
-                        int rangeMax = GlucoseRanges.rangePresetToMax(newValue.toString());
+                    if (!selectedPreset.equals("Custom range")) {
+                        int rangeMin = GlucoseRanges.getPresetMin(selectedPreset);
+                        int rangeMax = GlucoseRanges.getPresetMax(selectedPreset);
                         // min/max ranges are stored in mg/dl format
                         updatedUser.setCustom_range_min(rangeMin);
                         updatedUser.setCustom_range_max(rangeMax);

--- a/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/PreferencesActivity.java
@@ -47,6 +47,7 @@ import org.glucosio.android.R;
 import org.glucosio.android.analytics.Analytics;
 import org.glucosio.android.db.DatabaseHandler;
 import org.glucosio.android.db.User;
+import org.glucosio.android.tools.GlucoseRanges;
 import org.glucosio.android.tools.GlucosioConverter;
 import org.glucosio.android.tools.InputFilterMinMax;
 import org.glucosio.android.tools.LocaleHelper;
@@ -276,6 +277,16 @@ public class PreferencesActivity extends AppCompatActivity {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     updatedUser.setPreferred_range(newValue.toString());
+
+                    // look up the min/max values of the selected preset
+                    if (!newValue.toString().equals("Custom range")) {
+                        int rangeMin = GlucoseRanges.rangePresetToMin(newValue.toString());
+                        int rangeMax = GlucoseRanges.rangePresetToMax(newValue.toString());
+                        // min/max ranges are stored in mg/dl format
+                        updatedUser.setCustom_range_min(rangeMin);
+                        updatedUser.setCustom_range_max(rangeMax);
+                    }
+
                     updateDB();
                     return true;
                 }

--- a/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
+++ b/app/src/main/java/org/glucosio/android/fragment/OverviewFragment.java
@@ -691,8 +691,8 @@ public class OverviewFragment extends Fragment implements OverviewView {
             }
 
             FormatDateTime dateTime = new FormatDateTime(getActivity().getApplicationContext());
+            lastDateTextView.setText(dateTime.convertDateTime(presenter.getLastDateTime()));
 
-            lastDateTextView.setText(dateTime.convertDate(presenter.getLastDateTime()));
             GlucoseRanges ranges = new GlucoseRanges(getActivity().getApplicationContext());
             String color = ranges.colorFromReading(Integer.parseInt(presenter.getLastReading()));
             lastReadingTextView.setTextColor(ranges.stringToColor(color));

--- a/app/src/main/java/org/glucosio/android/presenter/OverviewPresenter.java
+++ b/app/src/main/java/org/glucosio/android/presenter/OverviewPresenter.java
@@ -127,9 +127,9 @@ public class OverviewPresenter {
     }
 
     public String getLastDateTime() {
-        java.text.DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd");
-
+        java.text.DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         return inputFormat.format(dB.getLastGlucoseReading().getCreated());
+
     }
 
     public String getRandomTip(TipsManager manager) {

--- a/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
+++ b/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
@@ -34,17 +34,17 @@ public class GlucoseRanges {
     private String preferredRange;
     private int userMin;
     private int userMax;
-    private final static String ADA = "ADA";
-    private final static String AACE = "AACE";
-    private final static String UKNICE = "UK NICE";
-    private final static int HYPER_LIMIT = 200;
-    private final static int HYPO_LIMIT = 70;
-    private final static int ADA_MIN = 80;
-    private final static int ADA_MAX = 180;
-    private final static int AACE_MIN = 110;
-    private final static int AACE_MAX = 140;
-    private final static int UKNICE_MIN = 81;
-    private final static int UKNICE_MAX = 153;
+    private static final String ADA = "ADA";
+    private static final String AACE = "AACE";
+    private static final String UKNICE = "UK NICE";
+    private static final int HYPER_LIMIT = 200;
+    private static final int HYPO_LIMIT = 70;
+    private static final int ADA_MIN = 80;
+    private static final int ADA_MAX = 180;
+    private static final int AACE_MIN = 110;
+    private static final int AACE_MAX = 140;
+    private static final int UKNICE_MIN = 81;
+    private static final int UKNICE_MAX = 153;
 
     public GlucoseRanges(Context context) {
         this.mContext = context;

--- a/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
+++ b/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
@@ -63,13 +63,13 @@ public class GlucoseRanges {
     public static int rangePresetToMin(String preset) {
         switch (preset) {
             case "ADA":
-                return 70;
+                return 80;
             case "AACE":
                 return 110;
             case "UK NICE":
-                return 72;
+                return 81;
             default:
-                return 70;
+                return 80;
         }
     }
 

--- a/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
+++ b/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
@@ -32,17 +32,26 @@ public class GlucoseRanges {
     private DatabaseHandler dB;
     private Context mContext;
     private String preferredRange;
-    private int customMin;
-    private int customMax;
-    private final static int hyperLimit = 200;
-    private final static int hypoLimit = 70;
+    private int userMin;
+    private int userMax;
+    private final static String ADA = "ADA";
+    private final static String AACE = "AACE";
+    private final static String UKNICE = "UK NICE";
+    private final static int HYPER_LIMIT = 200;
+    private final static int HYPO_LIMIT = 70;
+    private final static int ADA_MIN = 80;
+    private final static int ADA_MAX = 180;
+    private final static int AACE_MIN = 110;
+    private final static int AACE_MAX = 140;
+    private final static int UKNICE_MIN = 81;
+    private final static int UKNICE_MAX = 153;
 
     public GlucoseRanges(Context context) {
         this.mContext = context;
         dB = new DatabaseHandler(mContext);
         this.preferredRange = dB.getUser(1).getPreferred_range();
-        this.customMin = dB.getUser(1).getCustom_range_min();
-        this.customMax = dB.getUser(1).getCustom_range_max();
+        this.userMin = dB.getUser(1).getCustom_range_min();
+        this.userMax = dB.getUser(1).getCustom_range_max();
     }
 
     @VisibleForTesting
@@ -52,51 +61,51 @@ public class GlucoseRanges {
 
     @VisibleForTesting
     void setCustomMin(int customMin) {
-        this.customMin = customMin;
+        this.userMin = customMin;
     }
 
     @VisibleForTesting
     void setCustomMax(int customMax) {
-        this.customMax = customMax;
+        this.userMax = customMax;
     }
 
-    public static int rangePresetToMin(String preset) {
+    public static int getPresetMin(String preset) {
         switch (preset) {
-            case "ADA":
-                return 80;
-            case "AACE":
-                return 110;
-            case "UK NICE":
-                return 81;
+            case ADA:
+                return ADA_MIN;
+            case AACE:
+                return AACE_MIN;
+            case UKNICE:
+                return UKNICE_MIN;
             default:
-                return 80;
+                return ADA_MIN;
         }
     }
 
-    public static int rangePresetToMax(String preset) {
+    public static int getPresetMax(String preset) {
         switch (preset) {
-            case "ADA":
-                return 180;
-            case "AACE":
-                return 140;
-            case "UK NICE":
-                return 153;
+            case ADA:
+                return ADA_MAX;
+            case AACE:
+                return AACE_MAX;
+            case UKNICE:
+                return UKNICE_MAX;
             default:
-                return 180;
+                return ADA_MAX;
         }
     }
 
     public String colorFromReading(int reading) {
-        if (reading < hypoLimit) {
+        if (reading < HYPO_LIMIT) {
             // hypo limit 70
             return "purple";
-        } else if (reading > hyperLimit) {
+        } else if (reading > HYPER_LIMIT) {
             //  hyper limit 200
             return "red";
-        } else if (reading < customMin) {
+        } else if (reading < userMin) {
             // low limit
             return "blue";
-        } else if (reading > customMax) {
+        } else if (reading > userMax) {
             // high limit
             return "orange";
         } else {

--- a/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
+++ b/app/src/main/java/org/glucosio/android/tools/GlucoseRanges.java
@@ -34,16 +34,15 @@ public class GlucoseRanges {
     private String preferredRange;
     private int customMin;
     private int customMax;
+    private final static int hyperLimit = 200;
+    private final static int hypoLimit = 70;
 
     public GlucoseRanges(Context context) {
         this.mContext = context;
         dB = new DatabaseHandler(mContext);
         this.preferredRange = dB.getUser(1).getPreferred_range();
-        if (preferredRange.equals("Custom range")) {
-            this.customMin = dB.getUser(1).getCustom_range_min();
-            this.customMax = dB.getUser(1).getCustom_range_max();
-        }
-
+        this.customMin = dB.getUser(1).getCustom_range_min();
+        this.customMax = dB.getUser(1).getCustom_range_max();
     }
 
     @VisibleForTesting
@@ -61,48 +60,49 @@ public class GlucoseRanges {
         this.customMax = customMax;
     }
 
-    public String colorFromReading(int reading) {
-        // Check for Hypo/Hyperglycemia
-        if (reading < 70) {
-            return "purple";
-        } else if (reading > 70 && reading < 200) {
-            // if not check with custom ranges
-            switch (preferredRange) {
-                case "ADA":
-                    if (reading >= 70 & reading <= 180) {
-                        return "green";
-                    } else if (reading < 70) {
-                        return "blue";
-                    } else if (reading > 180) {
-                        return "orange";
-                    }
-                case "AACE":
-                    if (reading >= 110 & reading <= 140) {
-                        return "green";
-                    } else if (reading < 110) {
-                        return "blue";
-                    } else if (reading > 140) {
-                        return "orange";
-                    }
-                case "UK NICE":
-                    if (reading >= 72 & reading <= 153) {
-                        return "green";
-                    } else if (reading < 72) {
-                        return "blue";
-                    } else if (reading > 153) {
-                        return "orange";
-                    }
-                default:
-                    if (reading >= customMin & reading <= customMax) {
-                        return "green";
-                    } else if (reading < customMin) {
-                        return "blue";
-                    } else if (reading > customMax) {
-                        return "orange";
-                    }
-            }
+    public static int rangePresetToMin(String preset) {
+        switch (preset) {
+            case "ADA":
+                return 70;
+            case "AACE":
+                return 110;
+            case "UK NICE":
+                return 72;
+            default:
+                return 70;
         }
-        return "red";
+    }
+
+    public static int rangePresetToMax(String preset) {
+        switch (preset) {
+            case "ADA":
+                return 180;
+            case "AACE":
+                return 140;
+            case "UK NICE":
+                return 153;
+            default:
+                return 180;
+        }
+    }
+
+    public String colorFromReading(int reading) {
+        if (reading < hypoLimit) {
+            // hypo limit 70
+            return "purple";
+        } else if (reading > hyperLimit) {
+            //  hyper limit 200
+            return "red";
+        } else if (reading < customMin) {
+            // low limit
+            return "blue";
+        } else if (reading > customMax) {
+            // high limit
+            return "orange";
+        } else {
+            // in range
+            return "green";
+        }
     }
 
     public int stringToColor(String color) {


### PR DESCRIPTION
* display both date and time for last reading in overview
* display the preferred range choice in preferences. Closes #289
* updates to GlucoseRanges. range presets are now displayed in user preferences as they are selected. Resolves #91
* change minimum glucose ranges for ADA and UK NICE presets. Closes #363

