### PR TITLE
Fixes bugs related to exporting CSV by specifying a date range. When

### DIFF
--- a/app/src/main/java/org/glucosio/android/activity/MainActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/MainActivity.java
@@ -93,6 +93,8 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
+    public static final String FROM_DATE_DIALOG_TAG = "fromDateDialog";
+
     private BottomSheetBehavior bottomSheetBehavior;
     private ExportPresenter exportPresenter;
     private RadioButton exportRangeButton;
@@ -492,6 +494,8 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
                             now.get(Calendar.DAY_OF_MONTH)
                     );
                     dpd.getDatePicker().setMaxDate(System.currentTimeMillis());
+                    // We use this tag to determine which date the user has edited
+                    dpd.getDatePicker().setTag(FROM_DATE_DIALOG_TAG);
                     dpd.show();
                 }
             });
@@ -715,16 +719,15 @@ public class MainActivity extends AppCompatActivity implements DatePickerDialog.
     @Override
     public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
         // Check which dialog set the date
-        if (view.getTag().equals("fromDateDialog")) {
-            exportPresenter.setFrom(year, monthOfYear, dayOfMonth);
+        int monthToShow = monthOfYear + 1;
+        if (String.valueOf(view.getTag()).equals(FROM_DATE_DIALOG_TAG)) {
+            exportPresenter.setFrom(year, monthToShow, dayOfMonth);
 
-            int monthToShow = monthOfYear + 1;
             String date = +dayOfMonth + "/" + monthToShow + "/" + year;
             exportDialogDateFrom.setText(date);
         } else {
-            exportPresenter.setTo(year, monthOfYear, dayOfMonth);
+            exportPresenter.setTo(year, monthToShow, dayOfMonth);
 
-            int monthToShow = monthOfYear + 1;
             String date = +dayOfMonth + "/" + monthToShow + "/" + year;
             exportDialogDateTo.setText(date);
         }


### PR DESCRIPTION
the 'from' date picker was shown, and a date chosen, the app would
crash because NPE due to no tag being set on the date picker view.

Also, the date used to construct the date range was off by a month,
since Joda DateTime constructor uses months starting with 1 not 0.