### PR TITLE
Datalossfix4

### DIFF
--- a/app/src/main/java/org/glucosio/android/activity/AddA1CActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddA1CActivity.java
@@ -20,6 +20,7 @@
 
 package org.glucosio.android.activity;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.widget.TextView;
@@ -92,9 +93,42 @@ public class AddA1CActivity extends AddReadingActivity {
             presenter.dialogOnAddButtonPressed(this.getAddTimeTextView().getText().toString(),
                     this.getAddDateTextView().getText().toString(), readingTextView.getText().toString());
         }
+        isSubmit = true;
     }
 
     public void showErrorMessage() {
         Toast.makeText(getApplicationContext(), getString(R.string.dialog_error2), Toast.LENGTH_SHORT).show();
+    }
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editHb1ac", "");
+            spGenEditor.putString("editTime", "");
+            spGenEditor.putString("editDate", "");
+        } else {
+            spGenEditor.putString("editHb1ac", readingTextView.getText().toString());
+            spGenEditor.putString("editTime", this.getAddTimeTextView().getText().toString());
+            spGenEditor.putString("editDate", this.getAddDateTextView().getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("AddA1cActivity", MODE_PRIVATE);
+        readingTextView.setText(spGen.getString("editHb1ac", ""));
+        TextView addTimeTextView = findViewById(R.id.dialog_add_time);
+        TextView addDateTextView = findViewById(R.id.dialog_add_date);
+        addTimeTextView.setText(spGen.getString("editTime", ""));
+        addDateTextView.setText(spGen.getString("editDate", ""));
+        isSubmit = false;
     }
 }

--- a/app/src/main/java/org/glucosio/android/activity/AddCholesterolActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddCholesterolActivity.java
@@ -20,6 +20,7 @@
 
 package org.glucosio.android.activity;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.widget.TextView;
@@ -96,9 +97,48 @@ public class AddCholesterolActivity extends AddReadingActivity {
             presenter.dialogOnAddButtonPressed(this.getAddTimeTextView().getText().toString(),
                     this.getAddDateTextView().getText().toString(), totalChoTextView.getText().toString(), LDLChoTextView.getText().toString(), HDLChoTextView.getText().toString());
         }
+        isSubmit = true;
     }
 
     public void showErrorMessage() {
         Toast.makeText(getApplicationContext(), getString(R.string.dialog_error2), Toast.LENGTH_SHORT).show();
+    }
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editTotalCho", "");
+            spGenEditor.putString("editLDLCho", "");
+            spGenEditor.putString("editHDLCho", "");
+            spGenEditor.putString("editTime", "");
+            spGenEditor.putString("editDate", "");
+        } else {
+            spGenEditor.putString("editTotalCho", totalChoTextView.getText().toString());
+            spGenEditor.putString("editLDLCho", LDLChoTextView.getText().toString());
+            spGenEditor.putString("editHDLCho", HDLChoTextView.getText().toString());
+            spGenEditor.putString("editTime", this.getAddTimeTextView().getText().toString());
+            spGenEditor.putString("editDate", this.getAddDateTextView().getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("AddCholesterolActivity", MODE_PRIVATE);
+        totalChoTextView.setText(spGen.getString("editTotalCho", ""));
+        LDLChoTextView.setText(spGen.getString("editLDLCho", ""));
+        HDLChoTextView.setText(spGen.getString("editHDLCho", ""));
+        TextView addTimeTextView = findViewById(R.id.dialog_add_time);
+        TextView addDateTextView = findViewById(R.id.dialog_add_date);
+        addTimeTextView.setText(spGen.getString("editTime", ""));
+        addDateTextView.setText(spGen.getString("editDate", ""));
+        isSubmit = false;
     }
 }

--- a/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddGlucoseActivity.java
@@ -21,6 +21,7 @@
 package org.glucosio.android.activity;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputLayout;
@@ -210,6 +211,7 @@ public class AddGlucoseActivity extends AddReadingActivity {
                     this.getAddDateTextView().getText().toString(), readingTextView.getText().toString(),
                     readingType, notesEditText.getText().toString());
         }
+        isSubmit = true;
     }
 
     public void showErrorMessage() {
@@ -241,5 +243,40 @@ public class AddGlucoseActivity extends AddReadingActivity {
         super.onTimeSet(view, hourOfDay, minute);
         DecimalFormat df = new DecimalFormat("00");
         updateSpinnerTypeHour(Integer.parseInt(df.format(hourOfDay)));
+    }
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editGlucoseConcentration", "");
+            spGenEditor.putString("editNotes", "");
+            spGenEditor.putString("editTime", "");
+            spGenEditor.putString("editDate", "");
+        } else {
+            spGenEditor.putString("editGlucoseConcentration", readingTextView.getText().toString());
+            spGenEditor.putString("editNotes", notesEditText.getText().toString());
+            spGenEditor.putString("editTime", this.getAddTimeTextView().getText().toString());
+            spGenEditor.putString("editDate", this.getAddDateTextView().getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("AddGlucoseActivity", MODE_PRIVATE);
+        readingTextView.setText(spGen.getString("editGlucoseConcentration", ""));
+        notesEditText.setText(spGen.getString("editNotes", ""));
+        TextView addTimeTextView = findViewById(R.id.dialog_add_time);
+        TextView addDateTextView = findViewById(R.id.dialog_add_date);
+        addTimeTextView.setText(spGen.getString("editTime", ""));
+        addDateTextView.setText(spGen.getString("editDate", ""));
+        isSubmit = false;
     }
 }

--- a/app/src/main/java/org/glucosio/android/activity/AddKetoneActivity.java
+++ b/app/src/main/java/org/glucosio/android/activity/AddKetoneActivity.java
@@ -20,6 +20,7 @@
 
 package org.glucosio.android.activity;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.widget.TextView;
@@ -85,9 +86,42 @@ public class AddKetoneActivity extends AddReadingActivity {
             presenter.dialogOnAddButtonPressed(this.getAddTimeTextView().getText().toString(),
                     this.getAddDateTextView().getText().toString(), readingTextView.getText().toString().trim());
         }
+        isSubmit = true;
     }
 
     public void showErrorMessage() {
         Toast.makeText(getApplicationContext(), getString(R.string.dialog_error2), Toast.LENGTH_SHORT).show();
+    }
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editKetone", "");
+            spGenEditor.putString("editTime", "");
+            spGenEditor.putString("editDate", "");
+        } else {
+            spGenEditor.putString("editKetone", readingTextView.getText().toString());
+            spGenEditor.putString("editTime", this.getAddTimeTextView().getText().toString());
+            spGenEditor.putString("editDate", this.getAddDateTextView().getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("AddKetoneActivity", MODE_PRIVATE);
+        readingTextView.setText(spGen.getString("editKetone", ""));
+        TextView addTimeTextView = findViewById(R.id.dialog_add_time);
+        TextView addDateTextView = findViewById(R.id.dialog_add_date);
+        addTimeTextView.setText(spGen.getString("editTime", ""));
+        addDateTextView.setText(spGen.getString("editDate", ""));
+        isSubmit = false;
     }
 }


### PR DESCRIPTION
Hello developers of glucosio

I am using your app glucosio. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/Wvgz726

When the user tries to create a new add ketone entry. If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), the user will lose any data they had put into this page if the app is force closed by Android.

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/j3m7sBd). Therefore, the user does not have to fill in the data again thus improving the user experience.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim